### PR TITLE
Use $(vcsh list) instead of parsing the repos dir

### DIFF
--- a/vcsh
+++ b/vcsh
@@ -17,8 +17,7 @@ _vcsh()
     case "${prev}" in
 
     delete|enter|init|list-tracked|list-untracked|rename|run|status|upgrade)
-	    local repos=$(for x in `ls ~/.config/vcsh/repo.d/`; do echo ${x%".git"} ; done )
-	    COMPREPLY=( $(compgen -W "${repos}" -- ${cur}) )
+	    COMPREPLY=( $(compgen -W "$(vcsh list)" -- ${cur}) )
 		return 0
 		;;      
     esac


### PR DESCRIPTION
Since vcsh already supplies an option getting a list of existing repos, use that instead of parsing the contents of ~/.config/vcsh/repos.d/ 

This allows for situations where vcsh is configured to put the repos directory elsewhere.